### PR TITLE
[가계부] 지출/수입 항목 추가 페이지 JS

### DIFF
--- a/PayStory/pom.xml
+++ b/PayStory/pom.xml
@@ -15,7 +15,7 @@
 	<name>PayStory</name>
 	<description>Demo project for Spring Boot</description>
 	<properties>
-		<java.version>11</java.version>
+		<java.version>1.8</java.version>
 	</properties>
 	<dependencies>
 		<dependency>

--- a/PayStory/src/main/java/com/AourZ/PayStory/controller/AccountBookController.java
+++ b/PayStory/src/main/java/com/AourZ/PayStory/controller/AccountBookController.java
@@ -28,7 +28,8 @@ public class AccountBookController {
 	public String calendarSmall() {
 		return "accountBook/calendarSmall";
 	}
-
+	
+	/* 지출,수입 내역 추가 form */
 	@RequestMapping("/accountBook/add")
 	public String addForm() {
 		return "accountBook/addForm";

--- a/PayStory/src/main/resources/static/main/css/addForm.css
+++ b/PayStory/src/main/resources/static/main/css/addForm.css
@@ -7,9 +7,10 @@ input:active {outline: none;}
 textarea {resize: none;}
 
 /* 영수증 이미지 영역 */
-.imgArea {max-height: 550px;}
+.imgArea {max-height: 540px;}
 .form-row > .col,
 .form-row > [class*="col-"] {padding: 5px;}
+.fa-image.hidden {display: none;}
 
 /* 아이템 리스트 */
 .accordion > .card > .card-header {
@@ -47,4 +48,12 @@ textarea {resize: none;}
     bottom: 10%;
     left: 20%;
     font-size: 1.5rem;
+}
+
+
+/* 반응형: 가로 960px 이하 */
+@media (max-width: 990px) {
+	/* 영수증 이미지 영역을 제일 위로 */
+	.imgArea {order: 1;}
+	.formArea {order: 2;}
 }

--- a/PayStory/src/main/resources/static/main/css/addForm.css
+++ b/PayStory/src/main/resources/static/main/css/addForm.css
@@ -7,10 +7,14 @@ input:active {outline: none;}
 textarea {resize: none;}
 
 /* 영수증 이미지 영역 */
-.imgArea {max-height: 540px;}
+.imgArea {
+	max-height: 540px;
+	cursor: pointer;
+}
 .form-row > .col,
 .form-row > [class*="col-"] {padding: 5px;}
 .fa-image.hidden {display: none;}
+#receiptImg.hidden {display: none;}
 
 /* 아이템 리스트 */
 .accordion > .card > .card-header {
@@ -36,9 +40,9 @@ textarea {resize: none;}
 	background: none;	
 }
 
-/* .card-body {
+.card-body {
     padding: 1.25rem 1.25rem 0.5rem;
-} */
+}
 
 /* 아이템 추가/ 삭제 버튼 */
 .fa-plus-circle {font-size: 2rem;}

--- a/PayStory/src/main/resources/static/main/css/addForm.css
+++ b/PayStory/src/main/resources/static/main/css/addForm.css
@@ -6,9 +6,21 @@ input:focus,
 input:active {outline: none;}
 textarea {resize: none;}
 
+/* 파일 업로드  */
+input[type="file"] {
+	cursor: pointer;
+}
+
+/* 날짜 입력란 */
+input[type="datetime-local"]::-webkit-calendar-picker-indicator {
+	width: 50%;
+    background: url(https://cdn3.iconfinder.com/data/icons/linecons-free-vector-icons-pack/32/calendar-16.png) 95% 50% no-repeat;
+	cursor: pointer;
+}
+
 /* 영수증 이미지 영역 */
 .imgArea {
-	max-height: 540px;
+	max-height: 540px; 
 	cursor: pointer;
 }
 .form-row > .col,
@@ -37,7 +49,7 @@ textarea {resize: none;}
 .showItem:hover,
 .showItem:active {
 	border: none;
-	background: none;	
+	background: none;
 }
 
 .card-body {
@@ -46,7 +58,7 @@ textarea {resize: none;}
 
 /* 아이템 추가/ 삭제 버튼 */
 .fa-plus-circle {font-size: 2rem;}
-#itemWrap > .form-group{margin-bottom: 0;}
+#itemWrap > .form-group {margin-bottom: 0;}
 .fa-minus-circle {
 	position: absolute;
     bottom: 10%;
@@ -54,10 +66,34 @@ textarea {resize: none;}
     font-size: 1.5rem;
 }
 
+/* 금액 input */
+.expenditureItemAmount {text-align: right;}
 
+/* 추가 버튼 */
+/* #addItem {width: 60px;} */
+
+/* 삭제 버튼 */
+/* .removeItem {
+    width: 70%;
+    padding: 0;
+    position: absolute;
+    bottom: 10%;
+    left: 20%;
+}*/
+ 
 /* 반응형: 가로 960px 이하 */
 @media (max-width: 990px) {
 	/* 영수증 이미지 영역을 제일 위로 */
 	.imgArea {order: 1;}
 	.formArea {order: 2;}
+}
+
+/* 반응형: 가로 585px 이하 */
+@media (max-width: 585px) {
+	input[type="datetime-local"]::-webkit-calendar-picker-indicator {width: 30%;}
+}
+
+/* 반응형: 가로 380px 이하 */
+@media (max-width: 380px) {
+	input[type="datetime-local"]::-webkit-calendar-picker-indicator {width: 5%;}
 }

--- a/PayStory/src/main/resources/static/main/css/addForm.css
+++ b/PayStory/src/main/resources/static/main/css/addForm.css
@@ -7,8 +7,37 @@ input:active {outline: none;}
 textarea {resize: none;}
 
 /* 영수증 이미지 영역 */
+.imgArea {max-height: 550px;}
 .form-row > .col,
 .form-row > [class*="col-"] {padding: 5px;}
+
+/* 아이템 리스트 */
+.accordion > .card > .card-header {
+	height: 2.5rem;
+    padding: 0;
+}
+
+.fa-angle-down {
+	font-size: 1.8rem;
+    color: #858796;
+    transition: all ease 1s;
+}
+
+.fa-angle-down.open {
+    transform: rotate(180deg);
+    transition: all ease 1s;
+}
+
+.showItem:focus,
+.showItem:hover,
+.showItem:active {
+	border: none;
+	background: none;	
+}
+
+/* .card-body {
+    padding: 1.25rem 1.25rem 0.5rem;
+} */
 
 /* 아이템 추가/ 삭제 버튼 */
 .fa-plus-circle {font-size: 2rem;}

--- a/PayStory/src/main/resources/static/main/css/addForm.css
+++ b/PayStory/src/main/resources/static/main/css/addForm.css
@@ -69,18 +69,6 @@ input[type="datetime-local"]::-webkit-calendar-picker-indicator {
 /* 금액 input */
 .expenditureItemAmount {text-align: right;}
 
-/* 추가 버튼 */
-/* #addItem {width: 60px;} */
-
-/* 삭제 버튼 */
-/* .removeItem {
-    width: 70%;
-    padding: 0;
-    position: absolute;
-    bottom: 10%;
-    left: 20%;
-}*/
- 
 /* 반응형: 가로 960px 이하 */
 @media (max-width: 990px) {
 	/* 영수증 이미지 영역을 제일 위로 */

--- a/PayStory/src/main/resources/static/main/css/addForm.css
+++ b/PayStory/src/main/resources/static/main/css/addForm.css
@@ -19,10 +19,7 @@ input[type="datetime-local"]::-webkit-calendar-picker-indicator {
 }
 
 /* 영수증 이미지 영역 */
-#imgArea {
-	max-height: 560px; 
-	cursor: pointer;
-}
+#imgArea {max-height: 560px;}
 
 .form-row > .col,
 .form-row > [class*="col-"] {padding: 5px;}
@@ -34,7 +31,7 @@ input[type="datetime-local"]::-webkit-calendar-picker-indicator {
 .tooltipContent {
     display: none;
     position: absolute;
-    top: 8%;
+    top: 50%;
     left: 50%;
     width: 80%;
     height: 7%;
@@ -43,19 +40,24 @@ input[type="datetime-local"]::-webkit-calendar-picker-indicator {
     text-align: center;
     opacity: 0.8;
     border-radius: 3px;
-    transform: translate(-50%, -8%);
+    transform: translate(-50%, -50%);
     z-index: 1;
 }
 
-#imgArea:hover .tooltipContent {
+.tooltipContent p {margin: 0;}
+
+#receiptImgModal {width: 100%;}
+
+/* 영수증 이미지 있을 때 */
+.hasImage {cursor: pointer;}
+
+.hasImage:hover .tooltipContent {
 	display: flex;
     justify-content: center;
     align-items: center;
 }
 
-#imgArea:hover .tooltipContent.hidden {display: none;}
-
-.tooltipContent p {margin: 0;}
+.hasImage:hover .tooltipContent.hidden {display: none;}
 
 /* 아이템 리스트 */
 .accordion > .card > .card-header {

--- a/PayStory/src/main/resources/static/main/css/addForm.css
+++ b/PayStory/src/main/resources/static/main/css/addForm.css
@@ -19,14 +19,43 @@ input[type="datetime-local"]::-webkit-calendar-picker-indicator {
 }
 
 /* 영수증 이미지 영역 */
-.imgArea {
-	max-height: 540px; 
+#imgArea {
+	max-height: 560px; 
 	cursor: pointer;
 }
+
 .form-row > .col,
 .form-row > [class*="col-"] {padding: 5px;}
+
 .fa-image.hidden {display: none;}
+
 #receiptImg.hidden {display: none;}
+
+.tooltipContent {
+    display: none;
+    position: absolute;
+    top: 8%;
+    left: 50%;
+    width: 80%;
+    height: 7%;
+	background-color: #858796;
+    color: white;
+    text-align: center;
+    opacity: 0.8;
+    border-radius: 3px;
+    transform: translate(-50%, -8%);
+    z-index: 1;
+}
+
+#imgArea:hover .tooltipContent {
+	display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+#imgArea:hover .tooltipContent.hidden {display: none;}
+
+.tooltipContent p {margin: 0;}
 
 /* 아이템 리스트 */
 .accordion > .card > .card-header {
@@ -58,7 +87,9 @@ input[type="datetime-local"]::-webkit-calendar-picker-indicator {
 
 /* 아이템 추가/ 삭제 버튼 */
 .fa-plus-circle {font-size: 2rem;}
+
 #itemWrap > .form-group {margin-bottom: 0;}
+
 .fa-minus-circle {
 	position: absolute;
     bottom: 10%;

--- a/PayStory/src/main/resources/static/main/js/addForm.js
+++ b/PayStory/src/main/resources/static/main/js/addForm.js
@@ -33,10 +33,24 @@
 					'width':'100%',
 					'height':'95%'
 				});
+				$('#imgArea').addClass('hasImage');
+				$('.hasImage').attr({
+					'data-toggle' : 'modal',
+					'data-target' : '#receiptModal'
+				});
 			}
 			render.readAsDataURL(f);		
 		});
 	});
+	
+	// 이미지 영역 클릭 이벤트 : 이미지가 있으면 modal에 이미지 넣기 OK
+	$('#imgArea').on('click', function(){
+		if($(this).hasClass('hasImage')){
+			$('#receiptImgModal').attr('src', $(this).find('#receiptImg').attr('src'));
+		}else{
+			alert('이미지를 업로드 해주세요.');
+		}		
+	})
 	
 	// 반응형 CSS 설정 OK
 	$(window).resize(function(){

--- a/PayStory/src/main/resources/static/main/js/addForm.js
+++ b/PayStory/src/main/resources/static/main/js/addForm.js
@@ -37,7 +37,7 @@
 		});
 	});
 	
-	// 아이템 보기 버튼 클릭
+	// 아이템 보기 버튼 클릭 - css 적용
 	$('.showItem').on('click', function(){
 		$('.fa-angle-down').toggleClass('open');
 	});
@@ -89,4 +89,16 @@
 			alert('글자수는 100자까지 입력 가능합니다.'); 
 		} 
 	});
+	
+	/* 
+		화면 크기 가로 960px 이하면
+		- 아이콘 클릭 또는 후버시 영수증 이미지 확대 모달창 띄우기
+	*/
+	$(window).resize(function(){
+		console.log($(window).width())
+		if($(window).width() <= 990) {
+			$('#receiptImg').remove();
+		}
+	});
+	
 });

--- a/PayStory/src/main/resources/static/main/js/addForm.js
+++ b/PayStory/src/main/resources/static/main/js/addForm.js
@@ -9,6 +9,46 @@
 		if(e.keyCode == 13) e.preventDefault();
 	});
 	
+	/***** 영수증 이미지 영역 *****/
+	// 파일 업로드 OK
+	$("#uploadReceipt").on('change',function(e){
+		// 파일 이름 표시
+		let fileName = $(this).val();
+	  	$(".custom-file-label").text(fileName.substring(12));
+	  	
+	  	// 이미지 영역에 미리보기
+	  	let file = e.target.files;
+	  	let fileArr = Array.prototype.slice.call(file);
+	  	
+	  	fileArr.forEach(function(f){
+			if(!f.type.match('image.*')) {
+				alert("이미지 파일만 가능합니다.");
+				return;
+			}
+			
+			let render = new FileReader();
+			render.onload = function(e){
+				$('#receiptImg').attr('src', e.target.result);
+				$('#receiptImg').css({
+					'width':'100%',
+					'height':'95%'
+				});
+			}
+			render.readAsDataURL(f);		
+		});
+	});
+	
+	// 반응형 CSS 설정 OK
+	$(window).resize(function(){
+		if($(window).width() <= 990) {
+			$('#receiptImg').addClass('hidden');
+			$('.tooltipContent').addClass('hidden');
+		}else {
+			$('#receiptImg').removeClass('hidden');
+			$('.tooltipContent').removeClass('hidden');
+		}
+	});
+	
 	/******** 아이템 영역  ********/
 	// 아이템 보기 버튼 클릭 - css 적용 OK
 	$('.showItem').on('click', function(){
@@ -122,14 +162,5 @@
 			// 100자 넘으면 알림창 뜨도록 
 			alert('글자수는 100자까지 입력 가능합니다.'); 
 		} 
-	});
-	
-	/***** 영수증 이미지 영역 : 반응형 CSS 적용 *****/
-	$(window).resize(function(){
-		if($(window).width() <= 990) {
-			$('#receiptImg').addClass('hidden');
-		}else {
-			$('#receiptImg').removeClass('hidden');
-		}
 	});
 });

--- a/PayStory/src/main/resources/static/main/js/addForm.js
+++ b/PayStory/src/main/resources/static/main/js/addForm.js
@@ -19,6 +19,7 @@
 	  	let fileArr = Array.prototype.slice.call(file);
 	  	
 	  	fileArr.forEach(function(f){
+			$('.imgtext').text(" ");
 			if(!f.type.match('image.*')) {
 				alert("이미지 파일만 가능합니다.");
 				return;
@@ -34,6 +35,11 @@
 			}
 			render.readAsDataURL(f);		
 		});
+	});
+	
+	// 아이템 보기 버튼 클릭
+	$('.showItem').on('click', function(){
+		$('.fa-angle-down').toggleClass('open');
 	});
 	
 	// 아이템 추가 버튼 클릭

--- a/PayStory/src/main/resources/static/main/js/addForm.js
+++ b/PayStory/src/main/resources/static/main/js/addForm.js
@@ -19,7 +19,7 @@
 	  	let fileArr = Array.prototype.slice.call(file);
 	  	
 	  	fileArr.forEach(function(f){
-			$('.imgtext').text(" ");
+			// $('.imgtext').text(" ");
 			if(!f.type.match('image.*')) {
 				alert("이미지 파일만 가능합니다.");
 				return;
@@ -30,7 +30,7 @@
 				$('#receiptImg').attr('src', e.target.result);
 				$('#receiptImg').css({
 					'width':'100%',
-					'height':'100%'
+					'height':'95%'
 				});
 			}
 			render.readAsDataURL(f);		
@@ -50,25 +50,31 @@
 	
 	// 아이템 추가
 	function addItem(){
-		let itemHTML = '<div class="col-xl-7"><label for="expenditureItem">내용</label>'+
+		let itemHTML = '<div class="col-7">'+
 				   '<input type="text" class="form-control form-control-sm shadow-none" id="expenditureItem" required>'+'</div>';
-		let priceHTML = '<div class="col-xl-4"><label for="expenditureItemAmount">금액</label>'+
+		let priceHTML = '<div class="col-4">'+
 					  '<input type="text" class="form-control form-control-sm shadow-none" id="expenditureItemAmount" required>'+'</div>';
-		let removeBtn = '<div class="col-xl-1"><button class="removeItem btn shadow-none p-0"><i class="fas fa-minus-circle"></i></button></div>';
+		let removeBtn = '<div class="col-1"><button class="removeItem btn shadow-none p-0"><i class="fas fa-minus-circle"></i></button></div>';
 		let addItem = '<div class="item form-group form-row">'+itemHTML+priceHTML+removeBtn+'</div></div>';
 
 		$('#itemWrap').append(addItem);
 	} 
-	
 	// 아이템 삭제 버튼 클릭
 	$(document).on('click', '.removeItem', function(e){
 		e.preventDefault();
-		// 아이템이 한개면 삭제후 바로 새로 생성
-		if($('.item').length == 1){
-			$(this).parent().parent().remove(); 
-			addItem();
+		let currentItem = $(this).parent().parent();
+		
+		// 맨 위의 아이템이면
+		if(currentItem.hasClass('default')){
+			if(currentItem.next()){ // 다음 아이템이 있으면 다음 아이템 삭제
+				currentItem.next().remove();
+			}else { // 없으면 내용만 삭제
+				currentItem.find('#expenditureItem').val(" ");
+				currentItem.find('#expenditureItemAmount').val(" ");
+			}
+		}else {
+			currentItem.remove(); 
 		}
-		$(this).parent().parent().remove();
 	});
 	
 	// 메모 글자수 제한
@@ -97,7 +103,9 @@
 	$(window).resize(function(){
 		console.log($(window).width())
 		if($(window).width() <= 990) {
-			$('#receiptImg').remove();
+			$('#receiptImg').addClass('hidden');
+		}else {
+			$('#receiptImg').removeClass('hidden');
 		}
 	});
 	

--- a/PayStory/src/main/resources/static/main/js/addForm.js
+++ b/PayStory/src/main/resources/static/main/js/addForm.js
@@ -1,84 +1,112 @@
 /**
- * addForm.js
+ * addExpenditureForm.js
+ *  - 지출 항목 추가 form 이벤트
  */
- 
+
  $(function(){
-	// 엔터키 눌렀을 때 submit 안 되도록
+	/***** 엔터키 submit 안 되게 OK *****/
 	$(document).on('keydown', function(e){
-		if(e.keycode == 13) e.preventDefault();
-	})
-	
-	// 파일 업로드
-	$("#uploadReceipt").on('change',function(e){
-		// 파일 이름 표시
-		let fileName = $(this).val();
-	  	$(".custom-file-label").text(fileName.substring(12));
-	  	
-	  	// 이미지 영역에 미리보기
-	  	let file = e.target.files;
-	  	let fileArr = Array.prototype.slice.call(file);
-	  	
-	  	fileArr.forEach(function(f){
-			// $('.imgtext').text(" ");
-			if(!f.type.match('image.*')) {
-				alert("이미지 파일만 가능합니다.");
-				return;
-			}
-			
-			let render = new FileReader();
-			render.onload = function(e){
-				$('#receiptImg').attr('src', e.target.result);
-				$('#receiptImg').css({
-					'width':'100%',
-					'height':'95%'
-				});
-			}
-			render.readAsDataURL(f);		
-		});
+		if(e.keyCode == 13) e.preventDefault();
 	});
 	
-	// 아이템 보기 버튼 클릭 - css 적용
+	/******** 아이템 영역  ********/
+	// 아이템 보기 버튼 클릭 - css 적용 OK
 	$('.showItem').on('click', function(){
 		$('.fa-angle-down').toggleClass('open');
 	});
 	
-	// 아이템 추가 버튼 클릭
-	$('.addItem').on('click', function(e){
+	// 아이템 추가 OK
+	$('#addItem').on('click', function(e){
 		e.preventDefault();
-		addItem();
+		// 내용
+		let itemHTML = '<div class="col-7">'+
+				   '<input type="text" class="expenditureItem form-control form-control-sm shadow-none" required>'+'</div>';
+		// 금액
+		let priceHTML = '<div class="col-4">'+
+					  '<input type="text" class="expenditureItemAmount form-control form-control-sm shadow-none" required>'+'</div>';
+		// 삭제 버튼
+		let removeHTML = '<div class="col-1"><button class="removeItem btn shadow-none p-0"><i class="fas fa-minus-circle"></i></button></div>';
+		
+		let addItemDiv = '<div class="item form-group form-row" id="newItem">'+itemHTML+priceHTML+removeHTML+'</div></div>';
+		$('#itemWrap').append(addItemDiv);
 	});
 	
-	// 아이템 추가
-	function addItem(){
-		let itemHTML = '<div class="col-7">'+
-				   '<input type="text" class="form-control form-control-sm shadow-none" id="expenditureItem" required>'+'</div>';
-		let priceHTML = '<div class="col-4">'+
-					  '<input type="text" class="form-control form-control-sm shadow-none" id="expenditureItemAmount" required>'+'</div>';
-		let removeBtn = '<div class="col-1"><button class="removeItem btn shadow-none p-0"><i class="fas fa-minus-circle"></i></button></div>';
-		let addItem = '<div class="item form-group form-row">'+itemHTML+priceHTML+removeBtn+'</div></div>';
-
-		$('#itemWrap').append(addItem);
-	} 
-	// 아이템 삭제 버튼 클릭
-	$(document).on('click', '.removeItem', function(e){
+	// 아이템 삭제 OK
+	$(document).on('click', '.removeItem' ,function(e){
 		e.preventDefault();
 		let currentItem = $(this).parent().parent();
 		
+		// 삭제 전에 합계 금액에서 빼기 OK
+		let totalAmount = parseInt(withoutComma($('#expenditureTotalAmount').val()));
+		let thisItemAmount = parseInt(withoutComma($(this).parent().prev().find('.expenditureItemAmount').val()));
+		$('#expenditureTotalAmount').val(withComma(totalAmount-thisItemAmount));
+		
 		// 맨 위의 아이템이면
 		if(currentItem.hasClass('default')){
-			if(currentItem.next()){ // 다음 아이템이 있으면 다음 아이템 삭제
-				currentItem.next().remove();
-			}else { // 없으면 내용만 삭제
-				currentItem.find('#expenditureItem').val(" ");
-				currentItem.find('#expenditureItemAmount').val(" ");
-			}
+			currentItem.find('.expenditureItem').val(' ');
+			currentItem.find('.expenditureItemAmount').val(' ');
 		}else {
 			currentItem.remove(); 
 		}
 	});
 	
+	// 내용 입력란 keydown 이벤트 : 엔터 눌렀을 때, 입력한 값이 있다면 금액 입력란으로 focus OK
+	$(document).on('keydown', '.expenditureItem', function(e){
+		if(e.keyCode == 13) {
+			let inputAmount = $(this).parent().next().find('.expenditureItemAmount');
+			inputAmount.focus();
+		}
+	});
+	
+	// 금액 입력란 keydown 이벤트 : 엔터 눌렀을 때, 입력한 값이 있고, 다음 칸이 있다면 다음 내용 입력란 focus OK
+	$(document).on('keydown', '.expenditureItemAmount', function(e){
+		if(e.keyCode == 13) {
+			let inputItem = $(this).parent().parent().next().find('.expenditureItem');
+			if(inputItem) inputItem.focus();
+		}
+	});
+	
+	/***** 금액 입력 EVENT *****/
+	// 금액 천단위 콤마 생성
+	function withComma(num){
+		return num.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+	}
+	// 금액 콤마 해제
+	function withoutComma(num) {
+		return num.toString().replace(",", '');
+	}
+	
+	// 금액 입력란 keyup 이벤트
+	$(document).on('keyup', '.expenditureItemAmount', function(){
+		// 숫자만 입력
+		$(this).val($(this).val().replace(/[^0-9]/g, ''));
+		
+		// 콤마
+		let amount = $(this).val() || '0';
+		let amountWithComma = withComma(parseInt(amount));
+		$(this).val(amountWithComma);
+	});
+	
+	/***** 합계 ****/ 
+	function sumAmount(){
+		let sum = 0; 
+		$('.expenditureItemAmount').each(function(){
+			let itemAmount = $(this).val();
+			if(itemAmount){
+				sum += parseInt(withoutComma(itemAmount));
+			}
+		});
+		$('#expenditureTotalAmount').val(withComma(sum));
+	}
+	
+	// 금액 입력란에서 focusout 되면 합계 OK
+	$(document).on('focusout', '.expenditureItemAmount', function(){
+		sumAmount();
+	});
+	
+	/****** 메모 ******/
 	// 메모 글자수 제한
-	$('.memoBox').on('keyup', function(e){ 
+	$('.memoBox').on('keyup', function(){ 
 		let content = $(this).val(); 
 		// 글자수 세기 
 		if (content.length == 0 || content == '') { 
@@ -96,17 +124,12 @@
 		} 
 	});
 	
-	/* 
-		화면 크기 가로 960px 이하면
-		- 아이콘 클릭 또는 후버시 영수증 이미지 확대 모달창 띄우기
-	*/
+	/***** 영수증 이미지 영역 : 반응형 CSS 적용 *****/
 	$(window).resize(function(){
-		console.log($(window).width())
 		if($(window).width() <= 990) {
 			$('#receiptImg').addClass('hidden');
 		}else {
 			$('#receiptImg').removeClass('hidden');
 		}
 	});
-	
 });

--- a/PayStory/src/main/resources/static/main/js/addForm.js
+++ b/PayStory/src/main/resources/static/main/js/addForm.js
@@ -91,9 +91,12 @@
 		let currentItem = $(this).parent().parent();
 		
 		// 삭제 전에 합계 금액에서 빼기 OK
-		let totalAmount = parseInt(withoutComma($('#expenditureTotalAmount').val()));
-		let thisItemAmount = parseInt(withoutComma($(this).parent().prev().find('.expenditureItemAmount').val()));
-		$('#expenditureTotalAmount').val(withComma(totalAmount-thisItemAmount));
+		let thisItemAmount = $(this).parent().prev().find('.expenditureItemAmount').val();
+		if(thisItemAmount != ''){
+			let totalAmount = parseInt(withoutComma($('#expenditureTotalAmount').val()));
+			let currentAmount = totalAmount - parseInt(withoutComma(thisItemAmount));
+			$('#expenditureTotalAmount').val(withComma(currentAmount));
+		}
 		
 		// 맨 위의 아이템이면
 		if(currentItem.hasClass('default')){

--- a/PayStory/src/main/webapp/WEB-INF/views/accountBook/addForm.jsp
+++ b/PayStory/src/main/webapp/WEB-INF/views/accountBook/addForm.jsp
@@ -152,7 +152,7 @@
 										</div>
 									</div>
 									<!-- 이미지 영역 -->
-									<div id="imgArea" class="col-lg-4 border rounded text-center mb-3">
+									<div id="imgArea" class="col-lg-4 text-center border rounded mb-3">
 										<i class="fa fa-image"></i>
 										<span class="imgtext">영수증 이미지 미리보기</span>
 										<div class="tooltipContent"><p>클릭하여 이미지 크게 보기</p></div>
@@ -222,6 +222,7 @@
     <!-- End of Page Wrapper -->
     
     <!-- 영수증 이미지 Modal-->
+    <jsp:include page="/WEB-INF/views/accountBook/receiptImageModal.jsp" flush="true"/>
 
     <!-- Scroll to Top Button-->
     <a class="scroll-to-top rounded" href="#page-top">

--- a/PayStory/src/main/webapp/WEB-INF/views/accountBook/addForm.jsp
+++ b/PayStory/src/main/webapp/WEB-INF/views/accountBook/addForm.jsp
@@ -53,13 +53,13 @@
                     </div>
                     
                     <!-- Form panels -->
-					<div class="tab-content w-75 m-auto p-4 bg-white rounded">
+					<div class="tab-content p-4 bg-white rounded">
 						<!--지출 Form-->
 						<div class="tab-pane fade in show active" id="expenditure" role="tabpanel">
 							<form id="expenditureForm" class="my-4">
 								<div class="form-row px-3"> 
 									<!-- Form 영역 --> 
-									<div class="col-md-8"> 
+									<div class="formArea col-lg-8"> 
 										<!-- 영수증 등록 -->
 										<label for="uploadReceipt">영수증 등록</label>
 										<div class="custom-file mb-3"> 
@@ -108,15 +108,15 @@
 													  	<!-- 아이템 리스트 -->
 														<div id="itemWrap">
 															<div class="item form-group form-row">
-																<div class="col-xl-7">
+																<div class="col-7">
 																	<label for="expenditureItem">내용</label>
 																	<input type="text" class="form-control form-control-sm shadow-none" id="expenditureItem" required>
 																</div>
-																<div class="col-xl-4">
+																<div class="col-4">
 																	<label for="expenditureItemAmount">금액</label>
 																	<input type="text" class="form-control form-control-sm shadow-none" id="expenditureItemAmount" required>
 																</div>
-																<div class="col-xl-1">
+																<div class="col-1">
 																	<button class="removeItem btn shadow-none p-0"><i class="fas fa-minus-circle"></i></button>
 																</div>
 															</div>
@@ -131,8 +131,8 @@
 										</div>
 										<!-- 총 금액 -->
 										<div class="form-group row px-2 mt-2">
-											<label for="expenditureTotalAmount" class="col-xl-8 col-form-label text-right">총 금액</label>
-											<div class="col-xl-4">
+											<label for="expenditureTotalAmount" class="col-8 col-form-label text-right">총 금액</label>
+											<div class="col-4">
 												<input type="text" readonly class="form-control-plaintext text-right" id="expenditureTotalAmount" value="12,000원">
 											</div>
 										</div>
@@ -149,8 +149,9 @@
 										</div>
 									</div>
 									<!-- 이미지 영역 -->
-									<div class="imgArea col-md-4 border rounded text-center mb-3">
+									<div class="imgArea col-lg-4 border rounded text-center mb-3">
 										<span class="imgtext">영수증 이미지 미리보기</span>
+										<i class="fa fa-regular fa-image"></i>
 										<img id="receiptImg" />
 									</div>
 								</div>

--- a/PayStory/src/main/webapp/WEB-INF/views/accountBook/addForm.jsp
+++ b/PayStory/src/main/webapp/WEB-INF/views/accountBook/addForm.jsp
@@ -152,9 +152,10 @@
 										</div>
 									</div>
 									<!-- 이미지 영역 -->
-									<div class="imgArea col-lg-4 border rounded text-center mb-3">
+									<div id="imgArea" class="col-lg-4 border rounded text-center mb-3">
 										<i class="fa fa-image"></i>
 										<span class="imgtext">영수증 이미지 미리보기</span>
+										<div class="tooltipContent"><p>클릭하여 이미지 크게 보기</p></div>
 										<img id="receiptImg" />
 									</div>
 								</div>
@@ -219,6 +220,8 @@
         <!-- End of Content Wrapper -->
     </div>
     <!-- End of Page Wrapper -->
+    
+    <!-- 영수증 이미지 Modal-->
 
     <!-- Scroll to Top Button-->
     <a class="scroll-to-top rounded" href="#page-top">

--- a/PayStory/src/main/webapp/WEB-INF/views/accountBook/addForm.jsp
+++ b/PayStory/src/main/webapp/WEB-INF/views/accountBook/addForm.jsp
@@ -107,7 +107,7 @@
 													<div class="card-body">
 													  	<!-- 아이템 리스트 -->
 														<div id="itemWrap">
-															<div class="item form-group form-row">
+															<div class="item default form-group form-row">
 																<div class="col-7">
 																	<label for="expenditureItem">내용</label>
 																	<input type="text" class="form-control form-control-sm shadow-none" id="expenditureItem" required>
@@ -150,8 +150,8 @@
 									</div>
 									<!-- 이미지 영역 -->
 									<div class="imgArea col-lg-4 border rounded text-center mb-3">
+										<i class="fa fa-image"></i>
 										<span class="imgtext">영수증 이미지 미리보기</span>
-										<i class="fa fa-regular fa-image"></i>
 										<img id="receiptImg" />
 									</div>
 								</div>

--- a/PayStory/src/main/webapp/WEB-INF/views/accountBook/addForm.jsp
+++ b/PayStory/src/main/webapp/WEB-INF/views/accountBook/addForm.jsp
@@ -9,7 +9,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <meta name="description" content="Pay Story 가계부 - 수입/지출 내역 추가">
     <meta name="author" content="AourZ">
-    <title>수입 | 지출 내역 추가</title>
+    <title>[가계부] 수입 | 지출 내역 추가</title>
 
     <!-- Custom fonts for this template-->
     <link href="/bootstrap/vendor/fontawesome-free/css/all.min.css" rel="stylesheet" type="text/css">
@@ -39,8 +39,7 @@
 
                 <!-- Begin Page Content -->
                 <div class="container-fluid">
-
-                    <!-- Form Option : 지출 / 수입 -->
+                    <!-- Option Button : 지출 / 수입 선택 -->
                     <div class="d-flex align-items-center justify-content-center mb-4">
                         <ul class="nav nav-pills nav-justified w-50">
 						  <li class="nav-item mr-4">
@@ -54,8 +53,8 @@
                     
                     <!-- Form panels -->
 					<div class="tab-content p-4 bg-white rounded">
-						<!--지출 Form-->
 						<div class="tab-pane fade in show active" id="expenditure" role="tabpanel">
+							<!--지출 Form-->
 							<form id="expenditureForm" class="my-4">
 								<div class="form-row px-3"> 
 									<!-- Form 영역 --> 
@@ -63,18 +62,18 @@
 										<!-- 영수증 등록 -->
 										<label for="uploadReceipt">영수증 등록</label>
 										<div class="custom-file mb-3"> 
-											<input type="file" id="uploadReceipt" class="custom-file-input shadow-none" accept=".png, .jpg, .jpeg, .svg" aria-describedby="uploadReceipt">
+											<input type="file" id="uploadReceipt" name="expenditureImage" class="custom-file-input shadow-none" accept=".png, .jpg, .jpeg, .svg" aria-describedby="uploadReceipt">
 											<label class="custom-file-label shadow-none" for="uploadReceipt">파일 선택</label>
 										</div>
 										<!-- 날짜 -->
 										<div class="form-group"> 
 											<label for="date">날짜</label>
-											<input type="date" class="form-control shadow-none" id="date" required>
+											<input type="datetime-local" id="date" name="expenditureDate" class="form-control shadow-none" required>
 										</div>
 										<!-- 태그 -->
 										<div class="form-group"> 
 											<label for="tags">태그</label>
-											<select id="tags" class="form-control form-control-sm shadow-none" required>
+											<select id="tags" name="tagNo" class="form-control form-control-sm shadow-none" required>
 												<option selected disabled value="">태그를 선택해주세요.</option>
 												<option value="5">식품</option>
 												<option value="6">용품</option>
@@ -90,7 +89,7 @@
 										<!-- 상호명 -->
 										<div class="form-group">
 											<label for="expenditureSource">상호명</label>
-											<input type="text" class="form-control form-control-sm shadow-none" id="expenditureSource" required>
+											<input type="text" id="expenditureSource" name="expenditureSource" class="form-control form-control-sm shadow-none" required>
 										</div>
 										<!-- 아이템 아코디언 -->
 										<div class="accordion" id="itemAccordian">
@@ -107,23 +106,26 @@
 													<div class="card-body">
 													  	<!-- 아이템 리스트 -->
 														<div id="itemWrap">
+															<!-- 아이템 -->
 															<div class="item default form-group form-row">
 																<div class="col-7">
 																	<label for="expenditureItem">내용</label>
-																	<input type="text" class="form-control form-control-sm shadow-none" id="expenditureItem" required>
+																	<input type="text" name="expenditureItemName" class="expenditureItem form-control form-control-sm shadow-none" required>
 																</div>
 																<div class="col-4">
 																	<label for="expenditureItemAmount">금액</label>
-																	<input type="text" class="form-control form-control-sm shadow-none" id="expenditureItemAmount" required>
+																	<input type="text" name="expenditureItemPrice" class="expenditureItemAmount form-control form-control-sm shadow-none" required>
 																</div>
 																<div class="col-1">
 																	<button class="removeItem btn shadow-none p-0"><i class="fas fa-minus-circle"></i></button>
+																	<!-- <input type="button" class="removeItem btn shadow-none p-0" value="삭제"> -->
 																</div>
 															</div>
 														</div>
 														<!-- 아이템 추가 버튼 -->
 														<div class="addBtn w-100 d-flex justify-content-center">
-															<button class="addItem btn shadow-none"><i class="fas fa-plus-circle"></i></button>
+															<button id="addItem" class="btn shadow-none"><i class="fas fa-plus-circle"></i></button>
+															<!-- <input type="button" id="addItem" class="btn shadow-none" value="추가"> -->
 														</div>
 													</div>
 												</div>
@@ -132,8 +134,9 @@
 										<!-- 총 금액 -->
 										<div class="form-group row px-2 mt-2">
 											<label for="expenditureTotalAmount" class="col-8 col-form-label text-right">총 금액</label>
-											<div class="col-4">
-												<input type="text" readonly class="form-control-plaintext text-right" id="expenditureTotalAmount" value="12,000원">
+											<div class="col-4 d-flex">
+												<input type="text" id="expenditureTotalAmount" name="expenditureAmount" class="form-control-plaintext text-right" value="0" readonly>
+												<span style="padding: 0.5rem 0;">원</span>
 											</div>
 										</div>
 										<!-- 메모 -->
@@ -145,7 +148,7 @@
 													<span class="textTotal">/100자</span>
 												</div>
 											</div>
-											<textarea class="memoBox form-control shadow-none" id="expenditureMemo" rows="3" maxlength="100"></textarea>
+											<textarea id="expenditureMemo" name="expenditureMemo" class="memoBox form-control shadow-none" rows="3" maxlength="100"></textarea>
 										</div>
 									</div>
 									<!-- 이미지 영역 -->
@@ -156,24 +159,24 @@
 									</div>
 								</div>
 								<div class="d-flex align-items-center justify-content-center mt-3">
-									<button type="submit" class="btn btn-primary w-25 mr-3">등록</button>
-									<button type="reset" class="btn btn-primary w-25">취소</button>
+									<button type="submit" class="btn btn-primary w-25 mr-3 shadow-none">등록</button>
+									<button type="reset" class="btn btn-primary w-25 shadow-none">취소</button>
 								</div>
 							</form>
 						</div> <!--  End 지출 Form -->
 						
-						<!-- 수입 Form -->
 						<div class="tab-pane fade px-5" id="income" role="tabpanel">
+							<!-- 수입 Form -->
 							<form id="incomeForm" class="my-4">
 								<!-- 날짜 -->
 								<div class="form-group"> 
 									<label for="date">날짜</label>
-									<input type="date" class="form-control shadow-none" id="date" required>
+									<input type="datetime-local" id="date" name="incomeDate" class="form-control shadow-none" required>
 								</div>
 								<!-- 태그 -->
 								<div class="form-group"> 
 									<label for="tags">태그</label>
-									<select id="tags" class="form-control" required>
+									<select id="tags" name="tagNo" class="form-control" required>
 										<option selected disabled value="">태그를 선택해주세요.</option>
 										<option value="1">급여</option>
 										<option value="2">보너스</option>
@@ -185,27 +188,27 @@
 								<!-- 수입원 -->
 								<div class="form-group">
 									<label for="incomeSource">수입원</label>
-									<input type="text" class="form-control shadow-none" id="incomeSource" required>
+									<input type="text" id="incomeSource" name="incomeSource" class="form-control shadow-none" required>
 								</div>
 								<!-- 금액 -->
 								<div class="form-group">
 									<label for="incomeAmount">금액</label>
-									<input type="text" class="form-control shadow-none" id="incomeAmount" required>
+									<input type="text" id="incomeAmount" name="incomeAmount" class="form-control shadow-none" required>
 								</div>
 								<!-- 메모 -->
 								<div class="form-group">
 									<div class="textWrap d-flex align-item-center justify-content-between">
-										<label for="expenditureMemo">메모</label>
+										<label for="incomeMemo">메모</label>
 										<div class="textLength">
 											<span class="textCount">0</span>
 											<span class="textTotal">/100자</span>
 										</div>
 									</div>
-									<textarea class="memoBox form-control shadow-none" id="expenditureMemo" rows="3" maxlength="100"></textarea>
+									<textarea id="incomeMemo" name="incomeMemo" class="memoBox form-control shadow-none" rows="3" maxlength="100"></textarea>
 								</div>
 								<div class="d-flex align-items-center justify-content-center mt-3">
-									<button type="submit" class="btn btn-primary w-25 mr-3">등록</button>
-									<button type="reset" class="btn btn-primary w-25">취소</button>
+									<button type="submit" class="btn btn-primary w-25 mr-3 shadow-none">등록</button>
+									<button type="reset" class="btn btn-primary w-25 shadow-none">취소</button>
 								</div>
 							</form>							
 						</div> <!--  End 수입 Form -->

--- a/PayStory/src/main/webapp/WEB-INF/views/accountBook/addForm.jsp
+++ b/PayStory/src/main/webapp/WEB-INF/views/accountBook/addForm.jsp
@@ -92,25 +92,42 @@
 											<label for="expenditureSource">상호명</label>
 											<input type="text" class="form-control form-control-sm shadow-none" id="expenditureSource" required>
 										</div>
-										<!-- 아이템 -->
-										<div id="itemWrap">
-											<div class="item form-group form-row">
-												<div class="col-xl-7">
-													<label for="expenditureItem">내용</label>
-													<input type="text" class="form-control form-control-sm shadow-none" id="expenditureItem" required>
+										<!-- 아이템 아코디언 -->
+										<div class="accordion" id="itemAccordian">
+											<div class="card">
+												<div class="card-header" id="heading">
+													<h2 class="mb-0">
+														<button class="showItem btn btn-light btn-block text-left collapsed d-flex justify-content-between shadow-none py-2 px-3" type="button" data-toggle="collapse" data-target="#items" aria-expanded="false" aria-controls="items">
+														  상세 항목 
+														  <i class="fas fa-angle-down"></i>
+														</button>
+													</h2>
 												</div>
-												<div class="col-xl-4">
-													<label for="expenditureItemAmount">금액</label>
-													<input type="text" class="form-control form-control-sm shadow-none" id="expenditureItemAmount" required>
-												</div>
-												<div class="col-xl-1">
-													<button class="removeItem btn shadow-none p-0"><i class="fas fa-minus-circle"></i></button>
+												<div id="items" class="collapse" aria-labelledby="heading" data-parent="#itemAccordian">
+													<div class="card-body">
+													  	<!-- 아이템 리스트 -->
+														<div id="itemWrap">
+															<div class="item form-group form-row">
+																<div class="col-xl-7">
+																	<label for="expenditureItem">내용</label>
+																	<input type="text" class="form-control form-control-sm shadow-none" id="expenditureItem" required>
+																</div>
+																<div class="col-xl-4">
+																	<label for="expenditureItemAmount">금액</label>
+																	<input type="text" class="form-control form-control-sm shadow-none" id="expenditureItemAmount" required>
+																</div>
+																<div class="col-xl-1">
+																	<button class="removeItem btn shadow-none p-0"><i class="fas fa-minus-circle"></i></button>
+																</div>
+															</div>
+														</div>
+														<!-- 아이템 추가 버튼 -->
+														<div class="addBtn w-100 d-flex justify-content-center">
+															<button class="addItem btn shadow-none"><i class="fas fa-plus-circle"></i></button>
+														</div>
+													</div>
 												</div>
 											</div>
-										</div>
-										<!-- 아이템 추가 버튼 -->
-										<div class="addBtn w-100 d-flex justify-content-center">
-											<button class="addItem btn shadow-none"><i class="fas fa-plus-circle"></i></button>
 										</div>
 										<!-- 총 금액 -->
 										<div class="form-group row px-2 mt-2">
@@ -132,7 +149,8 @@
 										</div>
 									</div>
 									<!-- 이미지 영역 -->
-									<div class="col-md-4 border rounded text-center mb-3">
+									<div class="imgArea col-md-4 border rounded text-center mb-3">
+										<span class="imgtext">영수증 이미지 미리보기</span>
 										<img id="receiptImg" />
 									</div>
 								</div>

--- a/PayStory/src/main/webapp/WEB-INF/views/accountBook/receiptImageModal.jsp
+++ b/PayStory/src/main/webapp/WEB-INF/views/accountBook/receiptImageModal.jsp
@@ -1,0 +1,26 @@
+<%@ page language="java" contentType="text/html; charset=UTF-8"
+    pageEncoding="UTF-8"%>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<!DOCTYPE html>
+<html>
+	<body>
+		<div class="modal fade" id="receiptModal" tabindex="-1" role="dialog" aria-labelledby="receiptModalLabel" aria-hidden="true">
+			<div class="modal-dialog modal-dialog-centered modal-lg" role="document">
+				<div class="modal-content">
+					<div class="modal-header">
+						<h5 class="modal-title" id="receiptModalLabel">영수증 이미지</h5>
+						<button class="close" type="button" data-dismiss="modal" aria-label="Close">
+					    	<span aria-hidden="true">×</span>
+						</button>
+					</div>
+					<div class="modal-body">
+						<img id="receiptImgModal" />
+					</div>
+					<div class="modal-footer">
+						<button class="btn btn-secondary" type="button" data-dismiss="modal">확인</button>
+					</div>
+				</div>
+			</div>
+		</div>
+	</body>
+</html>

--- a/PayStory/src/main/webapp/WEB-INF/views/layout/boardTopMenu.jsp
+++ b/PayStory/src/main/webapp/WEB-INF/views/layout/boardTopMenu.jsp
@@ -6,6 +6,11 @@
 	<body>
 	    <nav class="navbar navbar-expand navbar-light bg-white topbar mb-4 static-top shadow">
 		   
+		   <!-- Sidebar Toggle (Topbar) -->
+		   <button id="sidebarToggleTop" class="btn btn-link d-md-none rounded-circle mr-3 shadow-none">
+               <i class="fa fa-bars"></i>
+           </button>
+		   
 		   <!-- Topbar Navbar -->
 		   <ul class="navbar-nav ml-auto">
 		       <!-- Nav Item - 내 가계부 -->


### PR DESCRIPTION
**2022.02.17 작업 완료**
- 지출 항목 페이지 이벤트 JS
   -  엔터키 submit 방지
   - 추가/ 삭제 버튼
   - 내용 입력란에서 enter 누르면 금액 입력란  focus
   - 금액 입력란에서 enter 누르면 다음 항목 내용 입력란  focus
   - 금액 입력란에 숫자만 입력되게 & 콤마 생성
   - 금액 입력란에서 focusout 되면 자동으로 합계
   - 메모 글자수 이벤트 (count, 제한)
   - 영수증 모달

- 영수증 이미지 클릭 시 모달창 띄우기