### PR TITLE
[공유가계부]owner 사진 오류 수정

### DIFF
--- a/PayStory/src/main/webapp/WEB-INF/views/accountBook/public/main.jsp
+++ b/PayStory/src/main/webapp/WEB-INF/views/accountBook/public/main.jsp
@@ -75,7 +75,9 @@
 											<c:when test="${shareMain.ownerImage == null}">
 												<img class="profile" src="<c:url value='/main/images/blankprofile.png'></c:url>" alt="">
 											</c:when>
-											
+											<c:when test="${shareMain.ownerImage == ''}">
+												<img class="profile" src="<c:url value='/main/images/blankprofile.png'></c:url>" alt="">
+											</c:when>
 											<c:otherwise>
 											    <img class="profile" src="<c:url value='/images/member/${shareMain.ownerNo}/${shareMain.ownerImage}'></c:url>"alt="">
 										    </c:otherwise>


### PR DESCRIPTION
owner가 null 값일때 기본이미지 정상 출력,

owner에 값이 아무것도 안들어가 있을때 오류 뜨던것 수정