### PR TITLE
[공유가계부]참여자 빈칸으로 둬도 오류 생기지 않게 수정

### DIFF
--- a/PayStory/src/main/java/com/AourZ/PayStory/controller/AccountBookController.java
+++ b/PayStory/src/main/java/com/AourZ/PayStory/controller/AccountBookController.java
@@ -906,7 +906,7 @@ public class AccountBookController {
 
 		for (int i = 0; i < shareAccountBook.getParticipant_list().length; i++) {
 			participant = shareAccountBook.getParticipant_list()[i];
-			if (participant == null) {
+			if (participant == null || participant == "") {
 				continue;
 			}
 			shareAccountBook.setParticipant(participant);


### PR DESCRIPTION
고생하셨습니다.